### PR TITLE
Replace the interface of the construction. v0.2.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,28 @@
 Changelog
 =============
 
+v0.2.0 (August 21, 2018)
+----------------------------
+
+- Change an interface of the construction of Rii drastically.
+  Now users can specify their codec explicitly.
+
+    Old:
+
+    .. code-block:: python
+
+        e = rii.Rii(M=32)
+        e.fit(vecs=Xt)
+
+    Now:
+
+    .. code-block:: python
+
+        codec = nanopq.PQ(M=32).fit(vecs=Xt)
+        e = rii.Rii(fine_quantizer=codec)
+
+- Rename the function from ``add_reconfigure`` to ``add_configure``
+
 
 v0.1.0 (August 12, 2018)
 ----------------------------

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ class BuildExt(build_ext):
 
 setup(
     name='rii',
-    version='0.1.0',
+    version='0.2.0',
     description='Fast and memory-efficient ANN with a subset-search functionality',
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/src/rii.h
+++ b/src/rii.h
@@ -18,7 +18,6 @@ namespace rii {
 class RiiCpp {
 public:
     RiiCpp() {}  // Shouldn't be default-constructed
-    //RiiCpp(int M, int Ks, bool verbose) : M_(M), Ks_(Ks), verbose_(verbose) {}
     RiiCpp(const py::array_t<float> &codewords, bool verbose);
 
     // ===== Functions that can be called from Python =====
@@ -61,23 +60,6 @@ public:
     std::vector<std::vector<int>> posting_lists_;  // (NumList, any)
 };
 
-
-//void RiiCpp::SetCodewords(const py::array_t<float> &codewords)
-//{
-//    assert(codewords_.empty());  // codewords should be set only once
-//    const auto &r = codewords.unchecked<3>();  // codewords must have ndim=3, with non-writable
-//    assert(M_ == (size_t) r.shape(0));
-//    assert(Ks_ == (size_t) r.shape(1));
-//    size_t Ds = (size_t) r.shape(2);
-//    codewords_.resize(M_, std::vector<std::vector<float>>(Ks_, std::vector<float>(Ds)));
-//    for (ssize_t m = 0; m < r.shape(0); ++m) {
-//        for (ssize_t ks = 0; ks < r.shape(1); ++ks) {
-//            for (ssize_t ds = 0; ds < r.shape(2); ++ds) {
-//                codewords_[m][ks][ds] = r(m, ks, ds);
-//            }
-//        }
-//    }
-//}
 
 RiiCpp::RiiCpp(const py::array_t<float> &codewords, bool verbose)
 {

--- a/tests/test_rii.py
+++ b/tests/test_rii.py
@@ -1,6 +1,7 @@
 from .context import rii
 import unittest
 import numpy as np
+import nanopq
 
 
 class TestSuite(unittest.TestCase):
@@ -8,32 +9,23 @@ class TestSuite(unittest.TestCase):
         np.random.seed(123)
 
     def test_construct(self):
-        M, Ks, codec = 4, 20, "pq"
-        e = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
-        self.assertEqual((e.M, e.Ks, e.codec), (M, Ks, codec))
+        M, Ks = 4, 20
+        N, D = 1000, 40
+        X = np.random.random((N, D)).astype(np.float32)
+        e = rii.Rii(fine_quantizer=nanopq.PQ(M=M, Ks=Ks, verbose=True).fit(vecs=X))
+        self.assertEqual(e.fine_quantizer.codewords.shape, (M, Ks, D/M))
+        self.assertEqual((e.M, e.Ks), (M, Ks))
         self.assertEqual(e.verbose, True)
         e.verbose = False
         self.assertEqual(e.verbose, False)
 
-    def test_fit(self):
-        M, Ks, codec = 4, 20, "pq"
-        e = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
-        N, D = 1000, 40
-        X = np.random.random((N, D)).astype(np.float32)
-        e.fit(vecs=X, iter=20, seed=123)
-        self.assertEqual(e.fine_quantizer.codewords.shape, (M, Ks, D/M))
-
-        # Can be called as a chain style
-        e2 = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True).fit(vecs=X, iter=20, seed=123)
-        self.assertTrue(np.allclose(e.codewords, e2.codewords))
-
     def test_add(self):
-        for codec in ["pq", "opq"]:
+        for codec in [nanopq.PQ, nanopq.OPQ]:
             M, Ks = 4, 20
-            e = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
             N, D = 1000, 40
             X = np.random.random((N, D)).astype(np.float32)
-            e.fit(vecs=X, iter=20, seed=123)
+            e = rii.Rii(fine_quantizer=codec(M=M, Ks=Ks, verbose=True).fit(vecs=X))
+
             self.assertEqual(e.N, 0)
             e.add(vecs=X, update_posting_lists=False)
             self.assertEqual(e.N, N)
@@ -48,12 +40,11 @@ class TestSuite(unittest.TestCase):
             self.assertEqual(e.N, 2 * N)
 
     def test_reconfigure(self):
-        for codec in ["pq", "opq"]:
+        for codec in [nanopq.PQ, nanopq.OPQ]:
             M, Ks = 4, 20
-            e = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
             N, D = 1000, 40
             X = np.random.random((N, D)).astype(np.float32)
-            e.fit(vecs=X, iter=20, seed=123)
+            e = rii.Rii(fine_quantizer=codec(M=M, Ks=Ks, verbose=True).fit(vecs=X))
             e.add(vecs=X, update_posting_lists=False)
             for nlist in [5, 100]:
                 e.reconfigure(nlist=nlist)
@@ -62,29 +53,30 @@ class TestSuite(unittest.TestCase):
                 self.assertEqual(len(e.posting_lists), nlist)
                 self.assertEqual(sum([len(plist) for plist in e.posting_lists]), N)
 
-    def test_add_reconfigure(self):
-        M, Ks, codec = 4, 20, "pq"
-        e1 = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
+    def test_add_configure(self):
+        M, Ks = 4, 20
         N, D = 1000, 40
         X = np.random.random((N, D)).astype(np.float32)
-        e1.fit(vecs=X, iter=20, seed=123)
-        e1.add_reconfigure(vecs=X, nlist=20)
-        e2 = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
-        e2.fit(vecs=X, iter=20, seed=123)
+        e1 = rii.Rii(fine_quantizer=nanopq.PQ(M=M, Ks=Ks, verbose=True).fit(vecs=X))
+        e1.add_configure(vecs=X, nlist=20)
+        e2 = rii.Rii(fine_quantizer=nanopq.PQ(M=M, Ks=Ks, verbose=True).fit(vecs=X))
         e2.add(vecs=X, update_posting_lists=False)
         e2.reconfigure(nlist=20)
-        # The result of add_reconfigure() should be the same as that of
+        # The result of add_configure() should be the same as that of
         # (1) add(updating_posting_lists=False) and (2) reconfigure()
         self.assertTrue(np.allclose(e1.codes, e2.codes))
         self.assertListEqual(e1.posting_lists, e2.posting_lists)
+        e3 = rii.Rii(fine_quantizer=nanopq.PQ(M=M, Ks=Ks, verbose=True).fit(vecs=X)).add_configure(vecs=X, nlist=20)
+        # Can be called as a chain
+        self.assertTrue(np.allclose(e1.codes, e3.codes))
+        self.assertListEqual(e1.posting_lists, e3.posting_lists)
 
     def test_query_linear(self):
-        M, Ks, codec = 4, 20, "pq"
-        e = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
+        M, Ks = 4, 20
         N, D = 1000, 40
         X = np.random.random((N, D)).astype(np.float32)
-        e.fit(vecs=X, iter=20, seed=123)
-        e.add_reconfigure(vecs=X, nlist=20)
+        e = rii.Rii(fine_quantizer=nanopq.PQ(M=M, Ks=Ks, verbose=True).fit(vecs=X))
+        e.add_configure(vecs=X, nlist=20)
 
         for n, q in enumerate(X[:10]):
             topk = 10
@@ -109,12 +101,11 @@ class TestSuite(unittest.TestCase):
             self.assertTrue(np.all([id in S for id in ids3]))
 
     def test_query_ivf(self):
-        M, Ks, codec = 20, 256, "pq"
-        e = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
+        M, Ks = 20, 256
         N, D = 1000, 40
         X = np.random.random((N, D)).astype(np.float32)
-        e.fit(vecs=X, iter=20, seed=123)
-        e.add_reconfigure(vecs=X, nlist=20)
+        e = rii.Rii(fine_quantizer=nanopq.PQ(M=M, Ks=Ks, verbose=True).fit(vecs=X))
+        e.add_configure(vecs=X, nlist=20)
 
         for n, q in enumerate(X[:10]):
             L = 200
@@ -153,13 +144,13 @@ class TestSuite(unittest.TestCase):
             self.assertListEqual(dists6, dists7)
 
     def test_query(self):
-        for codec in ["pq", "opq"]:
+        for codec in [nanopq.PQ, nanopq.OPQ]:
             M, Ks = 20, 256
-            e = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
             N, D = 1000, 40
             X = np.random.random((N, D)).astype(np.float32)
-            e.fit(vecs=X, iter=20, seed=123)
-            e.add_reconfigure(vecs=X)
+            e = rii.Rii(fine_quantizer=codec(M=M, Ks=Ks, verbose=True).fit(vecs=X))
+            e.add_configure(vecs=X, nlist=20)
+
             for n, q in enumerate(X[:10]):
                 topk=50
                 ids1, dists1 = e.query(q=q, topk=topk)
@@ -183,20 +174,18 @@ class TestSuite(unittest.TestCase):
                 ids3, dists3 = e.query(q=q, topk=5, target_ids=S)
                 self.assertTrue(np.all([id in S for id in ids3]))
 
-
     def test_pickle(self):
-        M, Ks, codec = 10, 256, "pq"
-        e1 = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
+        M, Ks = 10, 256
         N, D = 1000, 40
         X = np.random.random((N, D)).astype(np.float32)
-        e1.fit(vecs=X, iter=20, seed=123)
-        e1.add_reconfigure(vecs=X)
+        e1 = rii.Rii(fine_quantizer=nanopq.PQ(M=M, Ks=Ks, verbose=True).fit(vecs=X))
+        e1.add_configure(vecs=X, nlist=20)
 
         import pickle
         dumped = pickle.dumps(e1)
         e2 = pickle.loads(dumped)
-        self.assertEqual((e1.M, e1.Ks, e1.codec, e1.threshold),
-                         (e2.M, e2.Ks, e2.codec, e2.threshold))
+        self.assertEqual((e1.M, e1.Ks, e1.threshold),
+                         (e2.M, e2.Ks, e2.threshold))
 
         self.assertTrue(np.allclose(e1.coarse_centers, e2.coarse_centers))
         self.assertTrue(np.allclose(e1.codes, e2.codes))
@@ -204,12 +193,11 @@ class TestSuite(unittest.TestCase):
             self.assertListEqual(pl1, pl2)
 
     def test_clear(self):
-        M, Ks, codec = 4, 20, "pq"
-        e = rii.Rii(M=M, Ks=Ks, codec=codec, verbose=True)
+        M, Ks = 4, 20
         N, D = 1000, 40
         X = np.random.random((N, D)).astype(np.float32)
-        e.fit(vecs=X, iter=20, seed=123)
-        e.add_reconfigure(vecs=X)
+        e = rii.Rii(fine_quantizer=nanopq.PQ(M=M, Ks=Ks, verbose=True).fit(vecs=X))
+        e.add_configure(vecs=X, nlist=20)
         e.clear()
         self.assertTrue(e.threshold is None)
         self.assertEqual(e.N, 0)


### PR DESCRIPTION
- Replaced the interface of the construction for the Rii class
- Renamed the function name from `add_reconfigure` to `add_configure`
- This breaks a backward compatibility, so the version is updated to v0.2.0