### PR TITLE
Use SIMD for the L2 square distance computation

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 v0.2.2 (August XX, 2018)
 ----------------------------
 - `#14 <https://github.com/matsui528/rii/pull/14>`_ Build on Mac with clang (without OpenMP)
+- `#16 <https://github.com/matsui528/rii/pull/16>`_ SIMD implementation for squared L2 distance (SSE, AVX, and AVX512)
 
 
 v0.2.1 (August 24, 2018)

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ class BuildExt(build_ext):
             opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
         if not sys.platform == 'darwin':
             opts.append('-fopenmp')  # For pqk-means
+        opts.append('-march=native')  # For fast SIMD computation of L2 distance
         for ext in self.extensions:
             ext.extra_compile_args = opts
             if not sys.platform == 'darwin':

--- a/src/distance.h
+++ b/src/distance.h
@@ -1,0 +1,221 @@
+#ifndef DISTANCE_H
+#define DISTANCE_H
+
+#include <x86intrin.h>
+
+// These fast L2 squared distance codes (SSE and AVX) are from the Faiss library:
+// https://github.com/facebookresearch/faiss/blob/master/utils.cpp
+//
+// Based on them, AVX512 implementation is also prepared.
+// But it doesn't seem drastically fast. Only slightly faster than AVX:
+// (runtime) REF >> SSE >= AVX ~ AVX512
+
+namespace rii {
+
+// From Faiss.
+// Reference implementation
+float fvec_L2sqr_ref(const float *x, const float *y, size_t d)
+{
+    size_t i;
+    float res_ = 0;
+    for (i = 0; i < d; i++) {
+        const float tmp = x[i] - y[i];
+        res_ += tmp * tmp;
+    }
+    return res_;
+}
+
+
+// ========================= Reading functions ============================
+
+// Reading function for SSE, AVX, and AVX512
+// This function is from Faiss
+// reads 0 <= d < 4 floats as __m128
+static inline __m128 masked_read (int d, const float *x)
+{
+    assert (0 <= d && d < 4);
+    __attribute__((__aligned__(16))) float buf[4] = {0, 0, 0, 0};
+    switch (d) {
+      case 3:
+        buf[2] = x[2];
+      case 2:
+        buf[1] = x[1];
+      case 1:
+        buf[0] = x[0];
+    }
+    return _mm_load_ps (buf);
+    // cannot use AVX2 _mm_mask_set1_epi32
+}
+
+#ifdef __AVX__
+// Reading function for AVX and AVX512
+// This function is from Faiss
+// reads 0 <= d < 8 floats as __m256
+static inline __m256 masked_read_8 (int d, const float *x)
+{
+    assert (0 <= d && d < 8);
+    if (d < 4) {
+        __m256 res = _mm256_setzero_ps ();
+        res = _mm256_insertf128_ps (res, masked_read (d, x), 0);
+        return res;
+    } else {
+        __m256 res = _mm256_setzero_ps ();
+        res = _mm256_insertf128_ps (res, _mm_loadu_ps (x), 0);
+        res = _mm256_insertf128_ps (res, masked_read (d - 4, x + 4), 1);
+        return res;
+    }
+}
+#endif // __AVX__
+
+
+
+#ifdef __AVX512F__
+// Reading function for AVX512
+// reads 0 <= d < 16 floats as __m512
+static inline __m512 masked_read_16 (int d, const float *x)
+{
+    assert (0 <= d && d < 16);
+    if (d < 8) {
+        __m512 res = _mm512_setzero_ps ();
+        res = _mm512_insertf32x8 (res, masked_read_8 (d, x), 0);
+        return res;
+    } else {
+        __m512 res = _mm512_setzero_ps ();
+        res = _mm512_insertf32x8 (res, _mm256_loadu_ps (x), 0);
+        res = _mm512_insertf32x8 (res, masked_read_8 (d - 8, x + 8), 1);
+        return res;
+    }
+}
+
+#endif // __AVX512F__
+
+
+
+// ========================= Distance functions ============================
+
+#ifdef __AVX512F__
+
+// AVX512 implementation by Yusuke
+float fvec_L2sqr (const float *x, const float *y, size_t d)
+{
+    __m512 msum1 = _mm512_setzero_ps();
+
+    while (d >= 16) {
+        __m512 mx = _mm512_loadu_ps (x); x += 16;
+        __m512 my = _mm512_loadu_ps (y); y += 16;
+        const __m512 a_m_b1 = mx - my;
+        msum1 += a_m_b1 * a_m_b1;
+        d -= 16;
+    }
+
+    __m256 msum2 = _mm512_extractf32x8_ps(msum1, 1);
+    msum2 +=       _mm512_extractf32x8_ps(msum1, 0);
+
+    while (d >= 8) {
+        __m256 mx = _mm256_loadu_ps (x); x += 8;
+        __m256 my = _mm256_loadu_ps (y); y += 8;
+        const __m256 a_m_b1 = mx - my;
+        msum2 += a_m_b1 * a_m_b1;
+        d -= 8;
+    }
+
+    __m128 msum3 = _mm256_extractf128_ps(msum2, 1);
+    msum3 +=       _mm256_extractf128_ps(msum2, 0);
+
+    if (d >= 4) {
+        __m128 mx = _mm_loadu_ps (x); x += 4;
+        __m128 my = _mm_loadu_ps (y); y += 4;
+        const __m128 a_m_b1 = mx - my;
+        msum3 += a_m_b1 * a_m_b1;
+        d -= 4;
+    }
+
+    if (d > 0) {
+        __m128 mx = masked_read (d, x);
+        __m128 my = masked_read (d, y);
+        __m128 a_m_b1 = mx - my;
+        msum3 += a_m_b1 * a_m_b1;
+    }
+
+    msum3 = _mm_hadd_ps (msum3, msum3);
+    msum3 = _mm_hadd_ps (msum3, msum3);
+    return  _mm_cvtss_f32 (msum3);
+}
+
+#elif __AVX__
+
+// This function is from Faiss
+// AVX implementation
+float fvec_L2sqr (const float *x, const float *y, size_t d)
+{
+    __m256 msum1 = _mm256_setzero_ps();
+
+    while (d >= 8) {
+        __m256 mx = _mm256_loadu_ps (x); x += 8;
+        __m256 my = _mm256_loadu_ps (y); y += 8;
+        const __m256 a_m_b1 = mx - my;
+        msum1 += a_m_b1 * a_m_b1;
+        d -= 8;
+    }
+
+    __m128 msum2 = _mm256_extractf128_ps(msum1, 1);
+    msum2 +=       _mm256_extractf128_ps(msum1, 0);
+
+    if (d >= 4) {
+        __m128 mx = _mm_loadu_ps (x); x += 4;
+        __m128 my = _mm_loadu_ps (y); y += 4;
+        const __m128 a_m_b1 = mx - my;
+        msum2 += a_m_b1 * a_m_b1;
+        d -= 4;
+    }
+
+    if (d > 0) {
+        __m128 mx = masked_read (d, x);
+        __m128 my = masked_read (d, y);
+        __m128 a_m_b1 = mx - my;
+        msum2 += a_m_b1 * a_m_b1;
+    }
+
+    msum2 = _mm_hadd_ps (msum2, msum2);
+    msum2 = _mm_hadd_ps (msum2, msum2);
+    return  _mm_cvtss_f32 (msum2);
+}
+
+#else
+
+// This function is from Faiss
+// SSE implementation
+float fvec_L2sqr (const float *x, const float *y, size_t d)
+{
+    __m128 msum1 = _mm_setzero_ps();
+
+    while (d >= 4) {
+        __m128 mx = _mm_loadu_ps (x); x += 4;
+        __m128 my = _mm_loadu_ps (y); y += 4;
+        const __m128 a_m_b1 = mx - my;
+        msum1 += a_m_b1 * a_m_b1;
+        d -= 4;
+    }
+
+    if (d > 0) {
+        // add the last 1, 2 or 3 values
+        __m128 mx = masked_read (d, x);
+        __m128 my = masked_read (d, y);
+        __m128 a_m_b1 = mx - my;
+        msum1 += a_m_b1 * a_m_b1;
+    }
+
+    msum1 = _mm_hadd_ps (msum1, msum1);
+    msum1 = _mm_hadd_ps (msum1, msum1);
+    return  _mm_cvtss_f32 (msum1);
+}
+
+
+#endif
+
+
+
+
+} // namespace rii
+
+#endif // DISTANCE_H

--- a/src/rii.h
+++ b/src/rii.h
@@ -3,8 +3,8 @@
 
 #include <iostream>
 #include <cassert>
-
 #include "pqkmeans.h"
+#include "./distance.h"
 
 // For py::array_t
 // See http://pybind11.readthedocs.io/en/master/advanced/pycpp/numpy.html#direct-access
@@ -336,16 +336,7 @@ std::vector<std::vector<float> > RiiCpp::DTable(const py::array_t<float> &vec) c
     std::vector<std::vector<float>> dtable(M_, std::vector<float>(Ks_));
     for (size_t m = 0; m < M_; ++m) {
         for (size_t ks = 0; ks < Ks_; ++ks) {
-            // ===== Squared L2 distance =====
-            // The straightforward description:
-            float dist = 0;
-            for (size_t ds = 0; ds < Ds; ++ds) {
-                float diff = v(m * Ds + ds) - codewords_[m][ks][ds];
-                dist += diff * diff;
-            }
-            dtable[m][ks] = dist;
-            // ===== SSE version. These codes are as the same as the above ones =====
-            /* Not implemented yet */
+            dtable[m][ks] = fvec_L2sqr(&(v(m * Ds)), codewords_[m][ks].data(), Ds);
         }
     }
     return dtable;

--- a/tests/test_rii.py
+++ b/tests/test_rii.py
@@ -232,6 +232,17 @@ class TestSuite(unittest.TestCase):
         self.assertEqual(e.codes, None)
         self.assertEqual(len(e.posting_lists), 0)
 
+    ### For debugging ###
+    # def test_runtime(self):
+    #     import time
+    #     M, Ks, N, D = 8, 256, 100000, 128
+    #     X = np.random.random((N, D)).astype(np.float32)
+    #     e = rii.Rii(fine_quantizer=nanopq.PQ(M=M, Ks=Ks, verbose=True).fit(vecs=X[:1000])).add_configure(vecs=X)
+    #     Q = np.random.random((10000, D)).astype(np.float32)
+    #     t0 = time.time()
+    #     for q in Q:
+    #         e.query(q=q, topk=3, method='ivf')
+    #     print(time.time() - t0, "sec")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
See #13 

SSE, AVX, AVX512 implementations are introduced. I followed Faiss implementation for SSE and AVX: https://github.com/facebookresearch/faiss/blob/master/utils.cpp
Depending on your architecture, the faster one is automatically selected (AVX512>AVX>SSE)

Based on Faiss's implementation, I wrote an AVX512 version. But it doesn't drastically fast. Almost same as AVX. 

See this for isolated benchmark: https://gist.github.com/matsui528/583925f88fcb08240319030202588c74

The result on c5.2xlarge instance on AWS EC2 are:
- ref: 1345 msec
- sse: 371 msec
- avx: 262 msec
- avx512: 255 msec