### PR TITLE
Optimization for search

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Installation
 -------------
 You can install the stable version of the package via pip.
 The library works with Python 3.5+ on linux.
-Note that OpenMP is required for parallel search.
+Note that OpenMP is required for parallel encoding.
 
 
 ::

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 v0.2.3 (September XX, 2018)
 ----------------------------
 - `#21 <https://github.com/matsui528/rii/pull/21>`_ Bug fix
+- `#22 <https://github.com/matsui528/rii/pull/22>`_ Optimization for search
 
 
 v0.2.2 (August 31, 2018)

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -104,3 +104,7 @@ You can turn on/off the verbose flag via ``e.verbose = True`` or ``e.verbose = F
 decided by the verbose flag of the codec.
 
 
+Version
+---------------
+The version of the package can be checked via ``rii.__version__``.
+

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -33,7 +33,7 @@ Some useful tips for tuning of search parameters:
     passing it to the query function, and call :func:`rii.Rii.query` with
     ``sort_target_ids=False``.
 
-  - Try a smaller ``L`` such as ``e.query(q=q, L=e.L0 / 2)``.
+  - Try a smaller ``L`` such as ``e.query(q=q, L=int(e.L0 / 2))``.
     This is not strongly recommended because the accuracy gets worse).
 
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -29,7 +29,7 @@ after new items are added.
 
 Th core part of Rii is implemented in C++11, and bound to the Python interface
 by `pybind11 <https://github.com/pybind/pybind11>`_.
-The search is automatically parallelized by `OpenMP <https://www.openmp.org/>`_.
+Encoding is automatically parallelized by `OpenMP <https://www.openmp.org/>`_.
 The package is tested on linux with g++.
 It should work on Mac with clang (without OpenMP) as well, but not fully tested.
 

--- a/rii/__init__.py
+++ b/rii/__init__.py
@@ -1,3 +1,5 @@
 __all__ = ['Rii']
+__version__ = '0.2.2'
 
 from .rii import Rii
+

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
+import re
 
 with open('README.md') as f:
     readme = f.read()
@@ -10,6 +11,9 @@ with open('requirements.txt') as f:
     requirements = []
     for line in f:
         requirements.append(line.rstrip())
+
+with open('rii/__init__.py') as f:
+    version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
 
 class get_pybind_include(object):
@@ -97,15 +101,19 @@ class BuildExt(build_ext):
         if not sys.platform == 'darwin':
             opts.append('-fopenmp')  # For pqk-means
         opts.append('-march=native')  # For fast SIMD computation of L2 distance
+        opts.append('-mtune=native')  # Do optimization (It seems this doesn't boost, but just in case)
+        opts.append('-Ofast')  # This makes the program faster
+
         for ext in self.extensions:
             ext.extra_compile_args = opts
             if not sys.platform == 'darwin':
                 ext.extra_link_args = ['-fopenmp']  # Because of PQk-means
+
         build_ext.build_extensions(self)
 
 setup(
     name='rii',
-    version='0.2.2',
+    version=version,
     description='Fast and memory-efficient ANN with a subset-search functionality',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- Introduce a helper structure DistanceTable to aim a better locality
- Avoid omp parallel for some parts because it makes the search slower even for billion-scale
- Some compile flags for optimization. It seems -Ofast works well
- Accessor for `__version__`