### PR TITLE
add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "pybind11"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
Add pybind11 and setuptools as build time requirements to address pip install failures with `pip>=23.1`. Resolves #49 