### PR TITLE
Clean up the build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - uses: ilammy/msvc-dev-cmd@v1
+    - name: Install Rii
+      run: |
+        make build
     - name: Test with CC=${{ matrix.compiler }}
       env:
         CC: ${{ matrix.compiler }}

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ test:
 clean:
 	rm -rf build tmp dist *.egg-info *.so .eggs
 
-# build:
-# 	python setup.py sdist
+
 
 build:
 	pip install .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test clean build deploy test_deploy
+.PHONY: test clean build
 
 test:
 	python setup.py test
@@ -6,11 +6,14 @@ test:
 clean:
 	rm -rf build tmp dist *.egg-info *.so .eggs
 
+# build:
+# 	python setup.py sdist
+
 build:
-	python setup.py sdist
+	pip install .
 
-deploy: clean build
-	twine upload dist/*
+# deploy: clean build
+# 	twine upload dist/*
 
-test_deploy: clean build
-	twine upload --repository-url https://test.pypi.org/legacy/ dist/*	
+# test_deploy: clean build
+# 	twine upload --repository-url https://test.pypi.org/legacy/ dist/*	

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "pybind11"]
+requires = ["setuptools>=42", "pybind11>=2.9"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "pybind11>=2.9"]
+requires = ["setuptools>=64", "pybind11>=2.9"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 requires = ["setuptools", "pybind11"]
-build-backend = "setuptools.build_meta:__legacy__"
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+pybind11>=2.9
 nanopq
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pybind11>=2.9
 nanopq
 

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
     install_requires=requirements,
     setup_requires=['pybind11>=2.9'],
     ext_modules=ext_modules,
-    cmdclass={'build_ext': build_ext},
+    cmdclass={'build_ext': BuildExt},
     zip_safe=False,
     python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
+from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup, Extension, find_packages
-from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 import re
@@ -19,7 +19,7 @@ with open('rii/__init__.py') as f:
 
 
 ext_modules = [
-    Extension(
+    Pybind11Extension(
         'main',
         ['src/main.cpp',
          'src/pqkmeans.cpp'],  # For c++ pqkmeans
@@ -115,7 +115,7 @@ setup(
     install_requires=requirements,
     setup_requires=['pybind11>=2.9'],
     ext_modules=ext_modules,
-    cmdclass={'build_ext': BuildExt},
+    cmdclass={'build_ext': build_ext},
     zip_safe=False,
     python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -17,36 +17,12 @@ with open('rii/__init__.py') as f:
     version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
 
-class get_pybind_include(object):
-    """Helper class to determine the pybind11 include path
-
-    The purpose of this class is to postpone importing pybind11
-    until it is actually installed, so that the ``get_include()``
-    method can be invoked. """
-
-    def __init__(self, user=False):
-        try:
-            import pybind11
-        except ImportError:
-            if subprocess.call([sys.executable, '-m', 'pip', 'install', 'pybind11']):
-                raise RuntimeError('pybind11 install failed.')
-        self.user = user
-
-    def __str__(self):
-        import pybind11
-        return pybind11.get_include(self.user)
-
 
 ext_modules = [
     Extension(
         'main',
         ['src/main.cpp',
          'src/pqkmeans.cpp'],  # For c++ pqkmeans
-        include_dirs=[
-            # Path to pybind11 headers
-            get_pybind_include(),
-            get_pybind_include(user=True)
-        ],
         language='c++',
         undef_macros=['NDEBUG'],  # This makes sure assert() works
     ),


### PR DESCRIPTION
Simplify the build process by following the [official guideline](https://github.com/pybind/python_example/tree/master).

- Revise Makefile to install the library by `pip install .` (now the only proper way)
- Revise gh actions to run `pip install .` explicitly.
- Delete the manual installation of pybind11 in setup.py. Such an approach is deprecated.
- Delete the `legacy` tag in pyproject.toml. It seems we don't need it? Also, set the minimum version of pybind11 and setuptools.

Special thanks to @denkiwakame !