### PR TITLE
Build read-the-docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Dependencies required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
Now we need `.readthedocs.yaml` to build the document.