### PR TITLE
Use `python -m build` to build the library when uploading to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install build
 
     - name: Build package
       run: |
-        python setup.py sdist
+        python -m build
 
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
As `python setup.py sdist` is deprecated, replace it with `python -m build`.

https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary

