### PR TITLE
Set --sdist option for building the library

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Build package
       run: |
-        python -m build
+        python -m build --sdist
 
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Set `--sdist` option for `python -m build`. With this option, the result file is `dist/rii-0.2.11.tar.gz`. Without this option, the result file is like `dist/rii-0.2.11-cp312-cp312-linux_x86_64.whl`.

We need `rii-0.2.11.tar.gz` to upload it to pypi.